### PR TITLE
feat: 시/도 및 시군구 목록 조회 기능 추가

### DIFF
--- a/src/daos/manager/managerFuneralListDao.js
+++ b/src/daos/manager/managerFuneralListDao.js
@@ -1,5 +1,6 @@
 import { Op } from 'sequelize';
 import FuneralList from '../../models/funeral/funeralList.js';
+import { sequelize } from '../../config/database.js';
 
 const managerFuneralListDao = {
   /**
@@ -66,6 +67,61 @@ const managerFuneralListDao = {
       attributes: ['funeralListId', 'funeralId', 'funeralName', 'funeralAddress'],
       order: [['createdAt', 'DESC']],
     });
+  },
+
+  /**
+   * 등록된 장례식장의 시/도 목록 조회 (중복 제거 + 서울 우선 정렬)
+   * @returns {Promise<Array<string>>} 중복 제거된 시/도 목록 배열
+   */
+  async getRegions() {
+    // DISTINCT를 사용하여 중복 제거된 시/도 목록 조회
+    const regions = await FuneralList.findAll({
+      attributes: [[sequelize.fn('DISTINCT', sequelize.col('funeral_region')), 'region']],
+      where: {
+        funeralRegion: { [Op.ne]: null },
+      },
+      raw: true,
+    });
+
+    const regionNames = regions.map((item) => item.region);
+
+    // JavaScript에서 정렬: 서울을 맨 앞으로, 나머지는 가나다순
+    const sortedRegions = regionNames.sort((a, b) => {
+      if (a === '서울') return -1;
+      if (b === '서울') return 1;
+      return a.localeCompare(b, 'ko');
+    });
+
+    return sortedRegions;
+  },
+
+  /**
+   * 특정 시/도의 시군구 목록 조회 (중복 제거 + 가나다순 정렬)
+   * @param {string} region - 조회할 시/도명
+   * @returns {Promise<Array<string>>} 해당 시/도의 시군구 목록 배열
+   */
+  async getCities(region) {
+    // 특정 시/도에 속한 시군구 목록 조회
+    const cities = await FuneralList.findAll({
+      attributes: [
+        // DISTINCT로 중복 제거된 시군구 목록
+        [sequelize.fn('DISTINCT', sequelize.col('funeral_city')), 'city'],
+      ],
+      where: {
+        // 지정된 시/도와 일치하는 레코드만 조회
+        funeralRegion: region,
+        // NULL 값 제외
+        funeralCity: { [Op.ne]: null },
+      },
+      order: [
+        // 시군구명 가나다순 정렬
+        ['funeralCity', 'ASC'],
+      ],
+      raw: true, // 순수 JavaScript 객체로 반환
+    });
+
+    // 결과에서 시군구명만 추출하여 문자열 배열로 반환
+    return cities.map((item) => item.city);
   },
 };
 

--- a/src/routes/manager/managerFuneralList.js
+++ b/src/routes/manager/managerFuneralList.js
@@ -83,6 +83,46 @@ router.get(
       });
     }
   },
+
+  // 시/도 목록 조회
+  router.get('/regions', async (req, res) => {
+    try {
+      const result = await funeralListService.getRegions();
+
+      return res.status(200).json({
+        success: true,
+        data: result,
+      });
+    } catch (error) {
+      logger.error(error.message);
+      return res.status(500).json({
+        success: false,
+        message: '시/도 목록 조회 실패',
+        error: error.message,
+      });
+    }
+  }),
+
+  // 시/군/구 목록 조회
+  router.get('/cities', validateRequiredFields(['region'], 'query'), async (req, res) => {
+    try {
+      const { region } = req.query;
+
+      const result = await funeralListService.getCities(region);
+
+      return res.status(200).json({
+        success: true,
+        data: result,
+      });
+    } catch (error) {
+      logger.error(error.message);
+      return res.status(500).json({
+        success: false,
+        message: '시/군/구 목록 조회 실패',
+        error: error.message,
+      });
+    }
+  }),
 );
 
 export default router;

--- a/src/services/manager/funeralListService.js
+++ b/src/services/manager/funeralListService.js
@@ -40,6 +40,27 @@ const funeralListService = {
       },
     };
   },
+
+  /**
+   * 시/도 목록 조회
+   * @returns
+   */
+  async getRegions() {
+    const regions = await managerFuneralListDao.getRegions();
+
+    return regions;
+  },
+
+  /**
+   * 시/군/구 목록 조회
+   * @param {*} region
+   * @returns
+   */
+  async getCities(region) {
+    const cities = await managerFuneralListDao.getCities(region);
+
+    return cities;
+  },
 };
 
 export default funeralListService;


### PR DESCRIPTION
- 장례식장 DAO에 중복 제거된 시/도 및 시군구 목록 조회 메서드 추가
- 서비스 레이어에 해당 메서드 호출을 위한 getRegions 및 getCities 메서드 구현
- 라우터에 시/도 및 시군구 목록 조회를 위한 엔드포인트 추가