### PR TITLE
fix: 비밀번호 변경 시 해시화 작동 오류 관련 문제 해결

### DIFF
--- a/src/daos/manager/managerAuthDao.js
+++ b/src/daos/manager/managerAuthDao.js
@@ -40,9 +40,16 @@ export const findById = async (managerId) => {
 };
 
 export const updatePassword = async (managerId, newPassword) => {
-  console.log('🚀 ~ updatePassword ~ newPassword:', newPassword);
   try {
-    return await db.Manager.update({ managerPassword: newPassword }, { where: { managerId } });
+    const manager = await db.Manager.findByPk(managerId);
+    if (!manager) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+
+    manager.managerPassword = newPassword;
+    await manager.save();
+
+    return manager;
   } catch (error) {
     throw new Error('🔴 updatePassword 오류:' + error.message);
   }


### PR DESCRIPTION
기존의 비밀번호 변경 코드에서는 모델의 훅을 트리거 하지 않아서 비밀번호 변경 시 DB에 클라이언트로부터 받아온 평문의 비밀번호를 해시화하지 않고 그대로 저장하는 버그를 모델의 인스턴트 메서드를 이용하여 정상적으로 해시화 후 저장하도록 수정