### PR TITLE
fix: 장례식장 회원 비밀번호 변경 시 해시화 관련 오류 수정

### DIFF
--- a/src/daos/funeral/funeralAuthDao.js
+++ b/src/daos/funeral/funeralAuthDao.js
@@ -18,10 +18,15 @@ export const findById = async (funeralId) => {
 
 export const updatePassword = async (funeralId, newPassword) => {
   try {
-    return await db.Funeral.update(
-      { funeralPassword: newPassword }, // 해싱 없이 평문 저장
-      { where: { funeralId }, returning: true },
-    );
+    const funeral = await db.Funeral.findByPk(funeralId);
+    if (!funeral) {
+      throw new Error('사용자를 찾을 수 없습니다.');
+    }
+
+    funeral.funeralPassword = newPassword;
+    await funeral.save();
+
+    return funeral;
   } catch (error) {
     throw new Error(error);
   }

--- a/src/models/funeral/funeral.js
+++ b/src/models/funeral/funeral.js
@@ -91,11 +91,11 @@ class Funeral extends Sequelize.Model {
               funeral.funeralPassword = await bcrypt.hash(funeral.funeralPassword, 10);
             }
           },
-        },
-        beforeUpdate: async (funeral) => {
-          if (funeral.changed('funeralPassword')) {
-            funeral.funeralPassword = await bcrypt.hash(funeral.funeralPassword, 10);
-          }
+          beforeUpdate: async (funeral) => {
+            if (funeral.changed('funeralPassword')) {
+              funeral.funeralPassword = await bcrypt.hash(funeral.funeralPassword, 10);
+            }
+          },
         },
       },
     );


### PR DESCRIPTION
기존의 장례식장 회원 비밀번호 변경 시 평문 데이터 입력되었던 문제 정상적으로 해시화를 통해서 데이터가 입력되도록 수정

1. 모델 훅을 트리거하여 해시화 하도록 코드 수정
2. funeral model에 선언해놓았던 beforeUpdate가 hooks 객체 밖에서 선언되어서 정상적으로 읽히지 않음 